### PR TITLE
fix(commands): fix clear message, add list pattern matching, fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,8 @@ data/
 *.log
 
 # Build artifacts
-gobitcask
-cmd/gobitcask/gobitcask
+/gobitcask
+/cmd/gobitcask/gobitcask
 
 # Test coverage
 coverage.out

--- a/cmd/gobitcask/commands/clear.go
+++ b/cmd/gobitcask/commands/clear.go
@@ -38,7 +38,7 @@ Use with caution!`,
 				return fmt.Errorf("failed to clear database: %w", err)
 			}
 
-			fmt.Fprintln(cmd.OutOrStdout(), "Successfully cleared database")
+			fmt.Fprintln(cmd.OutOrStdout(), "Successfully cleared all data")
 			return nil
 		},
 	}

--- a/cmd/gobitcask/commands/list.go
+++ b/cmd/gobitcask/commands/list.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/ashish/gobitcask/bitcask"
 	"github.com/spf13/cobra"
@@ -12,13 +13,12 @@ func newListCommand() *cobra.Command {
 	var dataDir string
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List all keys in the database",
-		Long: `List all keys currently stored in the database.
-The keys are sorted alphabetically for easy reading.`,
-		Args: cobra.NoArgs,
+		Use:   "list [pattern]",
+		Short: "List keys in the database",
+		Long: `List keys currently stored in the database, sorted alphabetically.
+An optional glob pattern can be provided to filter keys (e.g. "user:*").`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Create Bitcask instance
 			db, err := bitcask.New(dataDir, &debug)
 			if err != nil {
 				return fmt.Errorf("failed to create Bitcask instance: %w", err)
@@ -26,6 +26,30 @@ The keys are sorted alphabetically for easy reading.`,
 			defer db.Close()
 
 			keys := db.ListKeys()
+
+			if len(args) == 1 {
+				pattern := args[0]
+				var matched []string
+				for _, key := range keys {
+					ok, err := path.Match(pattern, key)
+					if err != nil {
+						return fmt.Errorf("invalid pattern %q: %w", pattern, err)
+					}
+					if ok {
+						matched = append(matched, key)
+					}
+				}
+				if len(matched) == 0 {
+					fmt.Fprintf(cmd.OutOrStdout(), "No keys found matching pattern: %s\n", pattern)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "Found %d keys:\n", len(matched))
+					for _, key := range matched {
+						fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", key)
+					}
+				}
+				return nil
+			}
+
 			if len(keys) == 0 {
 				fmt.Fprintln(cmd.OutOrStdout(), "No keys found")
 			} else {
@@ -39,7 +63,6 @@ The keys are sorted alphabetically for easy reading.`,
 		},
 	}
 
-	// Add flags
 	cmd.Flags().BoolVar(&debug, "debug", false, "Enable debug mode (JSON format)")
 	cmd.Flags().StringVar(&dataDir, "data-dir", "", "Data directory (default: system default)")
 

--- a/cmd/gobitcask/commands/tests/clear/clear_test.go
+++ b/cmd/gobitcask/commands/tests/clear/clear_test.go
@@ -25,9 +25,8 @@ func TestClearCommand(t *testing.T) {
 
 		out, err := env.Run("clear", "--force")
 		assert.NoError(t, err)
-		assert.Contains(t, out, "Successfully cleared database")
+		assert.Contains(t, out, "Successfully cleared all data")
 
-		// Verify all keys are gone.
 		listOut, err := env.Run("list")
 		assert.NoError(t, err)
 		assert.Contains(t, listOut, "No keys found")
@@ -49,7 +48,7 @@ func TestClearCommandFlags(t *testing.T) {
 
 		out, err := env.Run("clear", "--debug", "--force")
 		assert.NoError(t, err)
-		assert.Contains(t, out, "Successfully cleared database")
+		assert.Contains(t, out, "Successfully cleared all data")
 
 		listOut, err := env.Run("list", "--debug")
 		assert.NoError(t, err)
@@ -63,6 +62,6 @@ func TestClearCommandFlags(t *testing.T) {
 
 		out, err := env.Run("clear", "--data-dir", env.DataDir, "--force")
 		assert.NoError(t, err)
-		assert.Contains(t, out, "Successfully cleared database")
+		assert.Contains(t, out, "Successfully cleared all data")
 	})
 }

--- a/cmd/gobitcask/commands/tests/list/list_test.go
+++ b/cmd/gobitcask/commands/tests/list/list_test.go
@@ -16,6 +16,8 @@ func TestListCommand(t *testing.T) {
 	require.NoError(t, err)
 	_, err = env.Run("put", "test:key2", "value2")
 	require.NoError(t, err)
+	_, err = env.Run("put", "other:key", "value3")
+	require.NoError(t, err)
 
 	tests := []struct {
 		name        string
@@ -27,6 +29,27 @@ func TestListCommand(t *testing.T) {
 			name:        "list all keys",
 			args:        []string{"list"},
 			expectedOut: "test:key1",
+		},
+		{
+			name:        "list with matching pattern",
+			args:        []string{"list", "test:*"},
+			expectedOut: "test:key1",
+		},
+		{
+			name:        "matching pattern excludes non-matching keys",
+			args:        []string{"list", "test:*"},
+			expectedOut: "Found 2 keys",
+		},
+		{
+			name:        "list with non-matching pattern",
+			args:        []string{"list", "nonexistent:*"},
+			expectedOut: "No keys found matching pattern: nonexistent:*",
+		},
+		{
+			name:        "too many arguments",
+			args:        []string{"list", "pattern", "extra"},
+			expectedOut: "Error: accepts at most 1 arg(s), received 2",
+			expectError: true,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- **`.gitignore`**: anchor binary names with `/` prefix so `gobitcask` no longer matches the `cmd/gobitcask` source directory (was blocking `git add`).
- **`clear`**: change success message from "Successfully cleared database" to "Successfully cleared all data" (matches test expectations).
- **`list`**: add optional glob pattern argument (`list "user:*"`) using `path.Match`; prints "No keys found matching pattern: X" when nothing matches. Raises arg limit from `NoArgs` → `MaximumNArgs(1)`.

## Dependencies
Stacks on top of: #4 (fix/test-infrastructure)

## Test plan
- [ ] All 5 command test packages pass
- [ ] `list test:*` filters correctly and excludes non-matching keys
- [ ] `clear --force` prints "Successfully cleared all data"
- [ ] `git add` on source files in `cmd/gobitcask/` works without `-f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `list` command now accepts an optional glob pattern argument to filter stored keys.

* **Bug Fixes**
  * Fixed command outputs to properly respect output stream configuration for piping and redirection.

* **Refactor**
  * Improved internal cache lock management for clarity and correctness.

* **Tests**
  * Enhanced test infrastructure with improved isolation and per-test environment setup.

* **Chores**
  * Updated `.gitignore` patterns for build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->