### PR TITLE
chore(cleanup): remove testdata artifact and tighten gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 # Data files
 data/
 *.db
+testdata/
 
 # Logs
 *.log


### PR DESCRIPTION
## Summary
- Remove leftover `testdata/data_1.db` from disk (was never tracked by git but caused confusion).
- Add `testdata/` to `.gitignore` so database files created during development can never accidentally be staged.

## Dependencies
Stacks on top of: #5 (fix/command-behavior)

## Test plan
- [ ] All 5 command test packages still pass
- [ ] `go build ./...` succeeds
- [ ] `testdata/` directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)