### PR TITLE
feat: add log compaction mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The Go implementation provides significant performance improvements over the Pyt
 Following the same roadmap as the Python implementation:
 
 - [x] Core storage engine
-- [ ] Log compaction mechanism
+- [x] Log compaction mechanism
 - [ ] REST API server
 - [ ] Distributed features (future)
 

--- a/bitcask/bitcask.go
+++ b/bitcask/bitcask.go
@@ -236,6 +236,11 @@ func (bc *Bitcask) SetCacheSize(size int) error {
 
 // initialize sets up the database state from existing files
 func (bc *Bitcask) initialize() error {
+	// Clean up leftover .tmp files from crashed compaction.
+	if err := bc.cleanupTmpFiles(); err != nil {
+		log.Printf("Warning: failed to clean up tmp files: %v", err)
+	}
+
 	// Find existing data files
 	dataFiles, err := bc.getDataFiles()
 	if err != nil {
@@ -301,7 +306,17 @@ func (bc *Bitcask) createNewDataFile() error {
 		bc.activeFile.Close()
 	}
 
-	bc.activeFileID++
+	// Find the highest existing file ID to avoid collisions after compaction.
+	dataFiles, err := bc.getDataFiles()
+	if err != nil {
+		// Fallback to simple increment.
+		bc.activeFileID++
+	} else if len(dataFiles) > 0 {
+		bc.activeFileID = dataFiles[len(dataFiles)-1] + 1
+	} else {
+		bc.activeFileID = 1
+	}
+
 	bc.activeFilePath = bc.getDataFilePath(bc.activeFileID)
 
 	// Create the file
@@ -338,6 +353,14 @@ func (bc *Bitcask) openActiveFile() error {
 	file, err := os.OpenFile(bc.activeFilePath, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open active file: %w", err)
+	}
+
+	// Seek to end so that Seek(0, io.SeekCurrent) in Put returns the correct
+	// write offset. O_APPEND ensures writes go to EOF, but the read cursor
+	// starts at 0 on macOS/POSIX.
+	if _, err := file.Seek(0, io.SeekEnd); err != nil {
+		file.Close()
+		return fmt.Errorf("failed to seek to end of active file: %w", err)
 	}
 
 	bc.activeFile = file
@@ -577,6 +600,14 @@ func (bc *Bitcask) ListKeys() []string {
 
 	sort.Strings(keys)
 	return keys
+}
+
+// RotateActiveFile closes the current active file and creates a new one.
+// The previous active file becomes immutable and eligible for compaction.
+func (bc *Bitcask) RotateActiveFile() error {
+	bc.mutex.Lock()
+	defer bc.mutex.Unlock()
+	return bc.createNewDataFile()
 }
 
 // Close closes the database and all cached file handles

--- a/bitcask/bitcask.go
+++ b/bitcask/bitcask.go
@@ -16,6 +16,11 @@ import (
 	"github.com/ashish/gobitcask/formats"
 )
 
+const (
+	// DefaultMaxEntriesPerFile is the max records in a single compacted output file.
+	DefaultMaxEntriesPerFile = 1000
+)
+
 // IndexEntry represents an entry in the in-memory index
 type IndexEntry struct {
 	FileID    int   `json:"file_id"`
@@ -62,6 +67,9 @@ type Bitcask struct {
 
 	// Lock for thread safety
 	mutex sync.RWMutex
+
+	// Compaction settings
+	maxEntriesPerFile int
 }
 
 // New creates a new Bitcask instance
@@ -82,13 +90,14 @@ func New(directory string, debugMode *bool) (*Bitcask, error) {
 	}
 
 	bc := &Bitcask{
-		dataDir:       dataDir,
-		debugMode:     debug,
-		format:        format,
-		index:         make(map[string]*IndexEntry),
-		readFileCache: make(map[int]*CacheEntry),
-		cacheMaxSize:  10, // Cache up to 10 read file handles
-		cacheStats:    CacheStats{LastAccess: time.Now()},
+		dataDir:           dataDir,
+		debugMode:         debug,
+		format:            format,
+		index:             make(map[string]*IndexEntry),
+		readFileCache:     make(map[int]*CacheEntry),
+		cacheMaxSize:      10, // Cache up to 10 read file handles
+		cacheStats:        CacheStats{LastAccess: time.Now()},
+		maxEntriesPerFile: DefaultMaxEntriesPerFile,
 	}
 
 	// Create data directory if it doesn't exist

--- a/bitcask/compaction.go
+++ b/bitcask/compaction.go
@@ -1,0 +1,282 @@
+package bitcask
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+// CompactionStats holds statistics from a compaction run.
+type CompactionStats struct {
+	FilesCompacted int
+	FilesCreated   int
+	LiveEntries    int
+	StaleEntries   int
+	Duration       time.Duration
+}
+
+// Compact merges all immutable data files, keeping only the latest value for
+// each live key. The active file is never compacted.
+//
+// Algorithm:
+//  1. Identify immutable file IDs (everything except activeFileID).
+//  2. For each live key whose index entry points to an immutable file,
+//     read the current value and re-write it to a new compacted file.
+//  3. Remove old immutable files.
+//  4. Invalidate file cache entries for removed files.
+//  5. Update the in-memory index to point to the new locations.
+func (bc *Bitcask) Compact() (*CompactionStats, error) {
+	bc.mutex.Lock()
+	defer bc.mutex.Unlock()
+
+	start := time.Now()
+
+	dataFiles, err := bc.getDataFiles()
+	if err != nil {
+		return nil, fmt.Errorf("compaction: failed to list data files: %w", err)
+	}
+
+	// Identify immutable files (not the active file).
+	var immutableFileIDs []int
+	for _, fid := range dataFiles {
+		if fid != bc.activeFileID {
+			immutableFileIDs = append(immutableFileIDs, fid)
+		}
+	}
+
+	if len(immutableFileIDs) == 0 {
+		return &CompactionStats{Duration: time.Since(start)}, nil
+	}
+
+	// Collect live keys that live in immutable files.
+	type liveEntry struct {
+		key   string
+		entry *IndexEntry
+	}
+	var liveKeys []liveEntry
+
+	immutableSet := make(map[int]bool, len(immutableFileIDs))
+	for _, fid := range immutableFileIDs {
+		immutableSet[fid] = true
+	}
+
+	for key, entry := range bc.index {
+		if immutableSet[entry.FileID] {
+			liveKeys = append(liveKeys, liveEntry{key: key, entry: entry})
+		}
+	}
+
+	// Count total records in immutable files to compute stale count.
+	totalRecords := 0
+	for _, fid := range immutableFileIDs {
+		totalRecords += bc.countRecordsInFile(fid)
+	}
+	staleCount := totalRecords - len(liveKeys)
+
+	// Write live entries to new compacted files.
+	// Pick file IDs higher than the current max to avoid collisions.
+	maxID := bc.activeFileID
+	for _, fid := range dataFiles {
+		if fid > maxID {
+			maxID = fid
+		}
+	}
+	nextCompactedID := maxID + 1
+	var compactedFiles []int
+
+	var currentFile *os.File
+	var currentFileID int
+	var currentEntryCount int
+
+	startNewCompactedFile := func() error {
+		if currentFile != nil {
+			if err := currentFile.Sync(); err != nil {
+				return err
+			}
+			currentFile.Close()
+		}
+		currentFileID = nextCompactedID
+		nextCompactedID++
+		path := bc.getDataFilePath(currentFileID) + ".tmp"
+		f, err := os.Create(path)
+		if err != nil {
+			return fmt.Errorf("compaction: failed to create compacted file: %w", err)
+		}
+		// Write format identifier.
+		if _, err := f.Write([]byte{bc.format.GetFormatIdentifier()}); err != nil {
+			f.Close()
+			return err
+		}
+		currentFile = f
+		currentEntryCount = 0
+		compactedFiles = append(compactedFiles, currentFileID)
+		return nil
+	}
+
+	// Only create compacted files if there are live keys to write.
+	if len(liveKeys) > 0 {
+		if err := startNewCompactedFile(); err != nil {
+			return nil, err
+		}
+
+		// Write each live entry.
+		for _, lk := range liveKeys {
+			// Read current value from the old file.
+			value, err := bc.readValueLocked(lk.entry)
+			if err != nil {
+				log.Printf("compaction: skipping key %q: %v", lk.key, err)
+				continue
+			}
+
+			// Encode record.
+			data, err := bc.format.EncodeRecord(lk.key, value, lk.entry.Timestamp)
+			if err != nil {
+				return nil, fmt.Errorf("compaction: failed to encode key %q: %w", lk.key, err)
+			}
+
+			// Rotate if needed.
+			if currentEntryCount >= bc.maxEntriesPerFile {
+				if err := startNewCompactedFile(); err != nil {
+					return nil, err
+				}
+			}
+
+			// Get position before write.
+			pos, err := currentFile.Seek(0, 2) // seek to end
+			if err != nil {
+				return nil, err
+			}
+
+			if _, err := currentFile.Write(data); err != nil {
+				return nil, fmt.Errorf("compaction: write failed: %w", err)
+			}
+
+			// Update index to point at new location.
+			bc.index[lk.key] = &IndexEntry{
+				FileID:    currentFileID,
+				ValueSize: len(data),
+				ValuePos:  pos,
+				Timestamp: lk.entry.Timestamp,
+			}
+			currentEntryCount++
+		}
+
+		// Flush and close the last compacted file.
+		if currentFile != nil {
+			currentFile.Sync()
+			currentFile.Close()
+		}
+	}
+
+	// Atomically rename .tmp → .db
+	for _, fid := range compactedFiles {
+		tmpPath := bc.getDataFilePath(fid) + ".tmp"
+		finalPath := bc.getDataFilePath(fid)
+		if err := os.Rename(tmpPath, finalPath); err != nil {
+			return nil, fmt.Errorf("compaction: rename failed: %w", err)
+		}
+	}
+
+	// Remove old immutable files and evict from cache.
+	for _, fid := range immutableFileIDs {
+		// Close cached handle if present.
+		if entry, ok := bc.readFileCache[fid]; ok {
+			entry.File.Close()
+			delete(bc.readFileCache, fid)
+		}
+		path := bc.getDataFilePath(fid)
+		if err := os.Remove(path); err != nil {
+			log.Printf("compaction: failed to remove old file %s: %v", path, err)
+		}
+	}
+
+	stats := &CompactionStats{
+		FilesCompacted: len(immutableFileIDs),
+		FilesCreated:   len(compactedFiles),
+		LiveEntries:    len(liveKeys),
+		StaleEntries:   staleCount,
+		Duration:       time.Since(start),
+	}
+
+	log.Printf("Compaction complete: %d files → %d files, %d live entries, %d stale entries removed in %v",
+		stats.FilesCompacted, stats.FilesCreated, stats.LiveEntries, stats.StaleEntries, stats.Duration)
+
+	return stats, nil
+}
+
+// readValueLocked reads the value for an index entry. Caller must hold bc.mutex.
+func (bc *Bitcask) readValueLocked(entry *IndexEntry) (interface{}, error) {
+	file, err := bc.getReadFileLocked(entry.FileID)
+	if err != nil {
+		return nil, err
+	}
+
+	filePath := bc.getDataFilePath(entry.FileID)
+	format, err := bc.detectFormat(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := file.Seek(entry.ValuePos, 0); err != nil {
+		return nil, err
+	}
+
+	_, value, _, _, isTombstone, err := format.ReadRecord(file)
+	if err != nil {
+		return nil, err
+	}
+	if isTombstone {
+		return nil, fmt.Errorf("unexpected tombstone")
+	}
+	return value, nil
+}
+
+// countRecordsInFile counts total records (including tombstones) in a data file.
+func (bc *Bitcask) countRecordsInFile(fileID int) int {
+	filePath := bc.getDataFilePath(fileID)
+	file, err := os.Open(filePath)
+	if err != nil {
+		return 0
+	}
+	defer file.Close()
+
+	format, err := bc.detectFormat(filePath)
+	if err != nil {
+		return 0
+	}
+
+	// Skip format identifier.
+	if _, err := file.Seek(1, 0); err != nil {
+		return 0
+	}
+
+	count := 0
+	for {
+		_, _, _, _, _, err := format.ReadRecord(file)
+		if err != nil {
+			break
+		}
+		count++
+	}
+	return count
+}
+
+// cleanupTmpFiles removes any .db.tmp files left by a crashed compaction.
+func (bc *Bitcask) cleanupTmpFiles() error {
+	entries, err := os.ReadDir(bc.dataDir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".db.tmp") {
+			path := bc.dataDir + "/" + e.Name()
+			log.Printf("Cleaning up leftover tmp file: %s", path)
+			if err := os.Remove(path); err != nil {
+				log.Printf("Warning: failed to remove tmp file %s: %v", path, err)
+			}
+		}
+	}
+	return nil
+}

--- a/bitcask/compaction_test.go
+++ b/bitcask/compaction_test.go
@@ -1,0 +1,202 @@
+package bitcask_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ashish/gobitcask/bitcask"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func countDataFiles(t *testing.T, dir string) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "data_*.db"))
+	require.NoError(t, err)
+	return len(matches)
+}
+
+func TestCompactReclaimsSpace(t *testing.T) {
+	dir, err := os.MkdirTemp("", "gobitcask-compact-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	debug := false
+	db, err := bitcask.New(dir, &debug)
+	require.NoError(t, err)
+
+	// Write 20 keys
+	for i := 0; i < 20; i++ {
+		require.NoError(t, db.Put(fmt.Sprintf("key:%d", i), fmt.Sprintf("val:%d", i)))
+	}
+
+	// Overwrite first 10
+	for i := 0; i < 10; i++ {
+		require.NoError(t, db.Put(fmt.Sprintf("key:%d", i), fmt.Sprintf("new:%d", i)))
+	}
+
+	// Delete 5 keys
+	for i := 10; i < 15; i++ {
+		require.NoError(t, db.Delete(fmt.Sprintf("key:%d", i)))
+	}
+
+	// Force multiple data files by closing and reopening
+	require.NoError(t, db.Close())
+	db, err = bitcask.New(dir, &debug)
+	require.NoError(t, err)
+
+	// Add more data to create second data file scenario
+	for i := 20; i < 30; i++ {
+		require.NoError(t, db.Put(fmt.Sprintf("key:%d", i), fmt.Sprintf("val:%d", i)))
+	}
+
+	// Count files before compaction
+	filesBefore := countDataFiles(t, dir)
+	require.GreaterOrEqual(t, filesBefore, 2, "need at least 2 data files for meaningful compaction test")
+
+	// Compact
+	stats, err := db.Compact()
+	require.NoError(t, err)
+	assert.Greater(t, stats.StaleEntries, 0)
+
+	// Verify all live keys still readable
+	for i := 0; i < 10; i++ {
+		val, err := db.Get(fmt.Sprintf("key:%d", i))
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("new:%d", i), val)
+	}
+	for i := 10; i < 15; i++ {
+		_, err := db.Get(fmt.Sprintf("key:%d", i))
+		assert.ErrorContains(t, err, "key not found")
+	}
+	for i := 15; i < 30; i++ {
+		val, err := db.Get(fmt.Sprintf("key:%d", i))
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("val:%d", i), val)
+	}
+
+	require.NoError(t, db.Close())
+}
+
+func TestCompactJSONFormat(t *testing.T) {
+	dir, err := os.MkdirTemp("", "gobitcask-compact-json-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	debug := true
+	db, err := bitcask.New(dir, &debug)
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, db.Put(fmt.Sprintf("j:%d", i), fmt.Sprintf("v:%d", i)))
+	}
+	// Overwrite all
+	for i := 0; i < 10; i++ {
+		require.NoError(t, db.Put(fmt.Sprintf("j:%d", i), fmt.Sprintf("new:%d", i)))
+	}
+
+	require.NoError(t, db.Close())
+	db, err = bitcask.New(dir, &debug)
+	require.NoError(t, err)
+
+	stats, err := db.Compact()
+	require.NoError(t, err)
+	assert.Equal(t, 10, stats.LiveEntries)
+
+	for i := 0; i < 10; i++ {
+		val, err := db.Get(fmt.Sprintf("j:%d", i))
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("new:%d", i), val)
+	}
+
+	require.NoError(t, db.Close())
+}
+
+func TestCompactNoImmutableFilesIsNoop(t *testing.T) {
+	dir, err := os.MkdirTemp("", "gobitcask-compact-noop-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	debug := false
+	db, err := bitcask.New(dir, &debug)
+	require.NoError(t, err)
+
+	require.NoError(t, db.Put("only", "key"))
+
+	stats, err := db.Compact()
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.FilesCompacted)
+	assert.Equal(t, 0, stats.FilesCreated)
+
+	val, err := db.Get("only")
+	require.NoError(t, err)
+	assert.Equal(t, "key", val)
+
+	require.NoError(t, db.Close())
+}
+
+func TestCompactPersistence(t *testing.T) {
+	dir, err := os.MkdirTemp("", "gobitcask-compact-persist-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	debug := false
+
+	// Phase 1: write data, close to create first immutable file.
+	db1, err := bitcask.New(dir, &debug)
+	require.NoError(t, err)
+	for i := 0; i < 15; i++ {
+		require.NoError(t, db1.Put(fmt.Sprintf("p:%d", i), i))
+	}
+	require.NoError(t, db1.Close())
+
+	// Phase 2: reopen, add more, compact.
+	db2, err := bitcask.New(dir, &debug)
+	require.NoError(t, err)
+	for i := 15; i < 20; i++ {
+		require.NoError(t, db2.Put(fmt.Sprintf("p:%d", i), i))
+	}
+	_, err = db2.Compact()
+	require.NoError(t, err)
+	require.NoError(t, db2.Close())
+
+	// Phase 3: reopen — index must rebuild from compacted + active files.
+	db3, err := bitcask.New(dir, &debug)
+	require.NoError(t, err)
+	defer db3.Close()
+
+	keys := db3.ListKeys()
+	assert.Len(t, keys, 20)
+
+	for i := 0; i < 20; i++ {
+		val, err := db3.Get(fmt.Sprintf("p:%d", i))
+		require.NoError(t, err)
+		assert.Equal(t, float64(i), val) // JSON numbers → float64
+	}
+}
+
+func TestStartupCleansTmpFiles(t *testing.T) {
+	dir, err := os.MkdirTemp("", "gobitcask-tmp-cleanup-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	debug := false
+	db, err := bitcask.New(dir, &debug)
+	require.NoError(t, err)
+	require.NoError(t, db.Put("k", "v"))
+	require.NoError(t, db.Close())
+
+	// Simulate crashed compaction: leave a .tmp file.
+	tmpFile := filepath.Join(dir, "data_999.db.tmp")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("garbage"), 0644))
+
+	// Reopen — should clean up the tmp file.
+	db2, err := bitcask.New(dir, &debug)
+	require.NoError(t, err)
+	defer db2.Close()
+
+	_, err = os.Stat(tmpFile)
+	assert.True(t, os.IsNotExist(err), ".tmp file should have been removed on startup")
+}

--- a/bitcask/compaction_test.go
+++ b/bitcask/compaction_test.go
@@ -42,12 +42,10 @@ func TestCompactReclaimsSpace(t *testing.T) {
 		require.NoError(t, db.Delete(fmt.Sprintf("key:%d", i)))
 	}
 
-	// Force multiple data files by closing and reopening
-	require.NoError(t, db.Close())
-	db, err = bitcask.New(dir, &debug)
-	require.NoError(t, err)
+	// Rotate to create a second file — first file becomes immutable.
+	require.NoError(t, db.RotateActiveFile())
 
-	// Add more data to create second data file scenario
+	// Add more data to the new active file
 	for i := 20; i < 30; i++ {
 		require.NoError(t, db.Put(fmt.Sprintf("key:%d", i), fmt.Sprintf("val:%d", i)))
 	}
@@ -97,9 +95,8 @@ func TestCompactJSONFormat(t *testing.T) {
 		require.NoError(t, db.Put(fmt.Sprintf("j:%d", i), fmt.Sprintf("new:%d", i)))
 	}
 
-	require.NoError(t, db.Close())
-	db, err = bitcask.New(dir, &debug)
-	require.NoError(t, err)
+	// Rotate to make the first file immutable.
+	require.NoError(t, db.RotateActiveFile())
 
 	stats, err := db.Compact()
 	require.NoError(t, err)
@@ -152,12 +149,13 @@ func TestCompactPersistence(t *testing.T) {
 	}
 	require.NoError(t, db1.Close())
 
-	// Phase 2: reopen, add more, compact.
+	// Phase 2: reopen, add more, rotate to make first file immutable, compact.
 	db2, err := bitcask.New(dir, &debug)
 	require.NoError(t, err)
 	for i := 15; i < 20; i++ {
 		require.NoError(t, db2.Put(fmt.Sprintf("p:%d", i), i))
 	}
+	require.NoError(t, db2.RotateActiveFile())
 	_, err = db2.Compact()
 	require.NoError(t, err)
 	require.NoError(t, db2.Close())

--- a/cmd/gobitcask/commands/compact.go
+++ b/cmd/gobitcask/commands/compact.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/ashish/gobitcask/bitcask"
+	"github.com/spf13/cobra"
+)
+
+func newCompactCommand() *cobra.Command {
+	var debug bool
+	var dataDir string
+
+	cmd := &cobra.Command{
+		Use:   "compact",
+		Short: "Compact data files by removing stale entries",
+		Long: `Merges immutable data files, keeping only the latest value for each live key.
+Reclaims disk space from overwrites and deletions.
+The active file is not compacted.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			db, err := bitcask.New(dataDir, &debug)
+			if err != nil {
+				return fmt.Errorf("failed to open database: %w", err)
+			}
+			defer func() {
+				if cerr := db.Close(); cerr != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to close db: %v\n", cerr)
+				}
+			}()
+
+			stats, err := db.Compact()
+			if err != nil {
+				return fmt.Errorf("compaction failed: %w", err)
+			}
+
+			if stats.FilesCompacted == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "Nothing to compact — only one active file.")
+				return nil
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Compaction complete:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "  Files compacted: %d → %d\n", stats.FilesCompacted, stats.FilesCreated)
+			fmt.Fprintf(cmd.OutOrStdout(), "  Live entries:    %d\n", stats.LiveEntries)
+			fmt.Fprintf(cmd.OutOrStdout(), "  Stale entries:   %d removed\n", stats.StaleEntries)
+			fmt.Fprintf(cmd.OutOrStdout(), "  Duration:        %v\n", stats.Duration)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&debug, "debug", false, "Enable debug mode (JSON format)")
+	cmd.Flags().StringVar(&dataDir, "data-dir", "", "Data directory (default: system default)")
+
+	return cmd
+}

--- a/cmd/gobitcask/commands/root.go
+++ b/cmd/gobitcask/commands/root.go
@@ -24,6 +24,7 @@ It provides efficient and reliable storage with features like:
 	rootCmd.AddCommand(newDeleteCommand())
 	rootCmd.AddCommand(newListCommand())
 	rootCmd.AddCommand(newClearCommand())
+	rootCmd.AddCommand(newCompactCommand())
 
 	return rootCmd
 }

--- a/cmd/gobitcask/commands/tests/compact/compact_test.go
+++ b/cmd/gobitcask/commands/tests/compact/compact_test.go
@@ -1,0 +1,83 @@
+package compact_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ashish/gobitcask/bitcask"
+	"github.com/ashish/gobitcask/cmd/gobitcask/commands/tests/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompactCommandNoop(t *testing.T) {
+	t.Run("compact with only active file reports nothing to compact", func(t *testing.T) {
+		env := helpers.New(t)
+		_, err := env.Run("put", "k1", "v1")
+		require.NoError(t, err)
+
+		out, err := env.Run("compact")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "Nothing to compact")
+	})
+}
+
+func TestCompactCommandWithData(t *testing.T) {
+	t.Run("compact after rotation reports stats", func(t *testing.T) {
+		// Seed data with rotation using the library (CLI has no rotate command).
+		dir, err := os.MkdirTemp("", "gobitcask-cli-compact-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir)
+
+		debug := false
+		db, err := bitcask.New(dir, &debug)
+		require.NoError(t, err)
+
+		for i := 0; i < 5; i++ {
+			require.NoError(t, db.Put("k", "overwrite"))
+		}
+		require.NoError(t, db.RotateActiveFile())
+		require.NoError(t, db.Put("k", "final"))
+		require.NoError(t, db.Close())
+
+		// Now run compact via CLI.
+		env := helpers.New(t)
+		env.DataDir = dir
+		out, err := env.Run("compact")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "Compaction complete")
+		assert.Contains(t, out, "Live entries:")
+		assert.Contains(t, out, "Stale entries:")
+	})
+}
+
+func TestCompactCommandRejectsArgs(t *testing.T) {
+	t.Run("compact rejects extra arguments", func(t *testing.T) {
+		env := helpers.New(t)
+		out, err := env.Run("compact", "extra")
+		assert.Error(t, err)
+		assert.Contains(t, out, "Error: unknown command")
+	})
+}
+
+func TestCompactCommandFlags(t *testing.T) {
+	t.Run("debug flag", func(t *testing.T) {
+		env := helpers.New(t)
+		_, err := env.Run("put", "--debug", "k", "v")
+		require.NoError(t, err)
+
+		out, err := env.Run("compact", "--debug")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "Nothing to compact")
+	})
+
+	t.Run("explicit data-dir flag", func(t *testing.T) {
+		env := helpers.New(t)
+		_, err := env.Run("put", "k", "v")
+		require.NoError(t, err)
+
+		out, err := env.Run("compact", "--data-dir", env.DataDir)
+		assert.NoError(t, err)
+		assert.Contains(t, out, "Nothing to compact")
+	})
+}


### PR DESCRIPTION
## Summary

Add a log compaction (merge) mechanism that reclaims disk space by removing stale and tombstone entries from immutable data files.

## What's new

### Engine layer (`bitcask/compaction.go`)
- **`Compact()`** — merges all immutable data files, keeping only the latest value for each live key. Returns `CompactionStats` with files compacted/created, live/stale entry counts, and duration.
- **Crash-safe strategy** — compacted data is written to `.tmp` files first, then atomically renamed to `.db`. On startup, any orphaned `.tmp` files from interrupted compactions are cleaned up.
- **`RotateActiveFile()`** — closes the current active file and opens a new one, making the old file immutable and eligible for compaction.
- **File rotation for compacted output** — respects `DefaultMaxEntriesPerFile` (1000) to keep output files bounded.

### CLI (`gobitcask compact`)
- New Cobra command: `gobitcask compact [--debug] [--data-dir DIR]`
- Reports stats on completion or "nothing to compact" when only one active file exists.

### Bug fix
- **O_APPEND position tracking** — `openActiveFile` now seeks to EOF after opening, fixing a bug where `Seek(0, SeekCurrent)` returned 0 instead of the actual file end on reopened files. This caused corrupted index entries on any close/reopen cycle.
- **Post-compaction ID collisions** — `createNewDataFile` now scans for the max existing file ID instead of blindly incrementing.

## Tests
- 5 engine tests: basic compaction, JSON format, noop, persistence after compaction, tmp file cleanup
- 4 CLI integration tests: noop, compaction with data, argument rejection, flag variants
- All existing tests continue to pass

## Roadmap
```
- [x] Core storage engine
- [x] Log compaction mechanism  ← this PR
- [ ] REST API server
- [ ] Distributed features
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full database compaction feature to optimize storage and reclaim disk space
  * Added new `compact` CLI subcommand to trigger compaction and view results (files processed, entries compacted, duration)
  * Added manual active file rotation capability

* **Documentation**
  * Updated roadmap to mark compaction feature as complete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->